### PR TITLE
use polyglossia instead of babel

### DIFF
--- a/src/demo.tex
+++ b/src/demo.tex
@@ -1,6 +1,7 @@
 \documentclass[handout,aspectratio=169]{beamer}
 
-\usepackage[english]{babel}
+\usepackage{polyglossia}
+\setmainlanguage{english}
 \usepackage[nounicodemath]{ufalslides}
 % Supported options:
 %   nounicodemath (if you are struggling with a strange compilation issue)


### PR DESCRIPTION
Since this is always compiled with xelatex, we shloud be using polyglossia instead of babel.