### PR TITLE
better default colors for bibliography

### DIFF
--- a/src/ufalslides.sty
+++ b/src/ufalslides.sty
@@ -96,6 +96,12 @@
 
 \setbeamersize{text margin left=15pt,text margin right=15pt}
 
+\setbeamertemplate{bibliography item}{}
+\setbeamercolor*{bibliography entry author}{fg={ufal}}
+\setbeamercolor*{bibliography entry title}{fg={black}}
+\setbeamercolor*{bibliography entry location}{fg={black}}
+\setbeamercolor*{bibliography entry note}{fg={black!40}}
+
 \def\maketitle{{%
     \begin{frame}[plain,noframenumbering]
         \begin{textblock*}{\paperwidth}(0pt,0pt)

--- a/ufalslides.sty
+++ b/ufalslides.sty
@@ -84,6 +84,12 @@
 
 \setbeamersize{text margin left=15pt,text margin right=15pt}
 
+\setbeamertemplate{bibliography item}{}
+\setbeamercolor*{bibliography entry author}{fg={ufal}}
+\setbeamercolor*{bibliography entry title}{fg={black}}
+\setbeamercolor*{bibliography entry location}{fg={black}}
+\setbeamercolor*{bibliography entry note}{fg={black!40}}
+
 \def\maketitle{{    \begin{frame}[plain,noframenumbering]
         \begin{textblock*}{\paperwidth}(0pt,0pt)
  		\ifdefined\course


### PR DESCRIPTION
This does not change anything unless nanbib is not loaded (e.g. when
using the `custombib` option).

Testování není triviální, je potřeba si přepsat demo tak, aby nepoužívalo natbib... Možná bychom mohli implementovat nějaký option, který místo natbibu rovnou načte něco jiného, pokud se dohodneme co (biblatex? nevím...).